### PR TITLE
Native Messaging for the MCP client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,121 @@
 # Gemini MCP Client (Firefox Extension)
 
-This is a lightweight Firefox extension that monitors `gemini.google.com` for chat responses from Gemini. It aims to detect and intercept tool calls made by Gemini.
+This is a lightweight Firefox extension that monitors `gemini.google.com` for chat responses from Gemini. It aims to detect and intercept tool calls made by Gemini, forwarding them to a local Python script via Native Messaging. The Python script can then process these calls and optionally send responses back to the extension to be injected into Gemini.
 
-## Current Functionality
+## Core Functionality
 
 *   Injects a content script into `gemini.google.com`.
 *   Uses a `MutationObserver` to watch for new messages in the chat.
-*   When a potential tool call (containing `<tool_code>`) is detected in a new message, it prints a debug message to the Browser Console.
+*   When a potential tool call (containing `<tool_code>`) is detected, it's sent to a background script.
+*   The background script forwards the tool call to a Python script (`mcp_native_host.py`) using Firefox's Native Messaging API.
+*   The Python script receives the tool call, prints it to its console (for debugging/logging).
+*   The architecture supports bidirectional communication, allowing the Python script to send a response back to the extension, which can then inject it into the Gemini chat window and auto-submit.
 
-## How to Install and Test (Temporary Add-on)
+## Setup Instructions
 
-1.  **Download or Clone:** Make sure you have the extension files (`manifest.json`, `content_script.js`, and this `README.md`) in a local directory.
-2.  **Open Firefox.**
-3.  **Navigate to Add-ons:**
-    *   Type `about:debugging` in the address bar and press Enter.
-    *   Alternatively, click the menu button (☰) -> Add-ons and themes -> Extensions.
-4.  **Load Temporary Add-on:**
-    *   In the `about:debugging` page, click on "This Firefox" (or "This Nightly", "This Developer Edition" depending on your Firefox version) on the left sidebar.
-    *   Click the "Load Temporary Add-on…" button.
-5.  **Select the Manifest File:**
-    *   Browse to the directory where you saved the extension files.
-    *   Select the `manifest.json` file and click "Open".
-6.  **Test the Extension:**
-    *   Navigate to `https://gemini.google.com`.
-    *   Open the Browser Console (you can usually do this by pressing `Ctrl+Shift+J` on Windows/Linux or `Cmd+Shift+J` on macOS).
-    *   Interact with Gemini. If Gemini produces a response that includes XML for a tool call (e.g., something containing `<tool_code>...</tool_code>`), you should see a debug message from the "[Gemini MCP Client]" in the console.
+Setting up this extension involves two main parts: loading the Firefox extension and configuring the Python native messaging host.
+
+### 1. Firefox Extension Setup
+
+   a. **Download or Clone:** Ensure you have all extension files (`manifest.json`, `content_script.js`, `background.js`, `mcp_native_host.py`, `mcp_native_host_manifest.json`, and this `README.md`) in a local directory.
+   b. **Open Firefox.**
+   c. **Navigate to Add-ons:**
+      *   Type `about:debugging` in the address bar and press Enter.
+      *   Alternatively, click the menu button (☰) -> Add-ons and themes -> Extensions.
+   d. **Load Temporary Add-on:**
+      *   In the `about:debugging` page, click on "This Firefox" (or your Firefox version) on the left sidebar.
+      *   Click the "Load Temporary Add-on…" button.
+   e. **Select the Manifest File:**
+      *   Browse to the directory where you saved the extension files.
+      *   Select the main extension `manifest.json` file and click "Open".
+
+### 2. Python Native Messaging Host Setup
+
+This is the more complex part and requires careful setup. The extension needs to communicate with the `mcp_native_host.py` script.
+
+   a. **Install Python:**
+      *   Ensure you have Python 3 installed. You can download it from [python.org](https://www.python.org/).
+      *   Verify it's in your system's PATH.
+
+   b. **Prepare the Python Script (`mcp_native_host.py`):**
+      *   This script is included in the repository.
+      *   **On Linux/macOS:** Make it executable: `chmod +x /path/to/your/mcp_native_host.py`
+      *   Ensure it has the correct shebang line at the top: `#!/usr/bin/env python3` (or your Python 3 path).
+      *   Place this script in a known location. For example, you can place it in the same directory where you will put the native messaging host manifest file (see next step), or another directory of your choice.
+
+   c. **Configure and Register the Native Messaging Host Manifest (`mcp_native_host_manifest.json`):**
+      This JSON file tells Firefox where to find your Python script and which extension can talk to it.
+      *   **Edit `mcp_native_host_manifest.json`:**
+          The provided `mcp_native_host_manifest.json` has a `"path"` field:
+          ```json
+          {
+            "name": "mcp_native_host",
+            "description": "Native Messaging Host for Gemini MCP Client to run Python script.",
+            "path": "mcp_native_host.py", // <-- THIS PATH MIGHT NEED TO BE ABSOLUTE
+            "type": "stdio",
+            "allowed_extensions": [
+              "gemini-mcp-client@example.com"
+            ]
+          }
+          ```
+          You **MUST** update the `"path"` value in `mcp_native_host_manifest.json` to be the **absolute path** to your `mcp_native_host.py` script.
+          For example:
+            - Windows: `"path": "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"` (use double backslashes) or you might need to invoke python directly like `"path": "C:\\Path\\To\\Python\\python.exe", "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"`. Simpler is often a .bat wrapper.
+            - Linux/macOS: `"path": "/home/yourname/path/to/mcp_native_host.py"`
+
+      *   **Place the edited `mcp_native_host_manifest.json` into the correct Firefox directory, naming the file `mcp_native_host.json` (matching the `"name"` field):**
+          *   **Windows:**
+              1. Open Registry Editor (`regedit`).
+              2. Navigate to `HKEY_CURRENT_USER\Software\Mozilla\NativeMessagingHosts\`. If `Mozilla` or `NativeMessagingHosts` doesn't exist, create the key(s).
+              3. Create a new key named `mcp_native_host`.
+              4. Set the `(Default)` value of this `mcp_native_host` key to the **full, absolute path** of your edited `mcp_native_host_manifest.json` file.
+                 Example: `C:\Users\YourName\path\to\the\mcp_native_host_manifest.json`
+          *   **Linux:**
+              Create the directory if it doesn't exist: `mkdir -p ~/.mozilla/native-messaging-hosts/`
+              Copy your edited `mcp_native_host_manifest.json` to this directory, **renaming it to `mcp_native_host.json`**:
+              `cp /path/to/your/edited/mcp_native_host_manifest.json ~/.mozilla/native-messaging-hosts/mcp_native_host.json`
+          *   **macOS:**
+              Create the directory if it doesn't exist: `mkdir -p ~/Library/Application\ Support/Mozilla/NativeMessagingHosts/`
+              Copy your edited `mcp_native_host_manifest.json` to this directory, **renaming it to `mcp_native_host.json`**:
+              `cp /path/to/your/edited/mcp_native_host_manifest.json ~/Library/Application\ Support/Mozilla/NativeMessagingHosts/mcp_native_host.json`
+
+   d. **Verify Extension ID:**
+      The `mcp_native_host_manifest.json` allows connections from `"gemini-mcp-client@example.com"`. This ID is defined in the extension's `manifest.json` under `browser_specific_settings.gecko.id`. If you change it there, you must change it in `mcp_native_host_manifest.json` too.
+
+### 3. Testing and Debugging
+
+1.  **Load the Extension:** Follow step 1.
+2.  **Open Gemini:** Navigate to `https://gemini.google.com`.
+3.  **Open Browser Console:** In Firefox, press `Ctrl+Shift+J` (Windows/Linux) or `Cmd+Shift+J` (macOS). Look for logs from "Gemini MCP Client content script" and "Background script".
+4.  **Trigger a Tool Call:** Interact with Gemini in a way that you expect might generate a tool call.
+5.  **Check Python Script Output:**
+    *   When the native host is invoked by Firefox, its `print_debug()` messages (sent to `stderr`) might not be easily visible.
+    *   To debug the Python script:
+        *   Try running Firefox from a terminal. Sometimes `stderr` from native hosts is printed there.
+        *   Temporarily modify `mcp_native_host.py` to log to a file for easier debugging:
+          ```python
+          # At the top of mcp_native_host.py
+          # import sys
+          # def print_debug(message):
+          #     with open("/tmp/mcp_host_debug.log", "a") as f: # Choose a writable path
+          #         f.write(str(message) + '\n')
+          ```
+6.  **Browser Toolbox:** For advanced debugging of the extension itself (background script, popups, etc.), use the Browser Toolbox: `Ctrl+Shift+Alt+I` (or Tools > Browser Tools > Browser Toolbox). Connect to the main process.
+
+## How it Works (Briefly)
+
+1.  `content_script.js` on `gemini.google.com` sees a tool call.
+2.  It sends the tool call data to `background.js`.
+3.  `background.js` starts `mcp_native_host.py` (via the registered native messaging host manifest).
+4.  `background.js` sends the data to `mcp_native_host.py` over `stdin`.
+5.  `mcp_native_host.py` prints the received data (for now) and can send a JSON response back via `stdout`.
+6.  `background.js` receives the response and forwards it to `content_script.js`.
+7.  `content_script.js` injects the response into Gemini's input field and tries to submit it.
 
 ## Future Development
 
-*   More precise parsing of tool call XML.
-*   Sending intercepted calls to defined MCP servers.
-*   Returning MCP server responses to Gemini.
-
+*   More precise XML parsing of tool calls in `content_script.js`.
+*   Actual implementation of MCP server communication in `mcp_native_host.py`.
+*   Robust error handling and user feedback within the extension.
+*   Refining DOM selectors for Gemini's chat input and send button for better reliability.
 ```

--- a/background.js
+++ b/background.js
@@ -1,0 +1,109 @@
+// background.js
+
+const nativeHostName = "mcp_native_host";
+let port = null;
+
+console.log("Background script loaded.");
+
+// Function to send a message to the native host
+function sendToNativeHost(message) {
+  if (port) {
+    try {
+      port.postMessage(message);
+      console.log("Sent to native host:", message);
+    } catch (e) {
+      console.error("Error sending message to native host:", e);
+      console.error("Message was:", message);
+      // Attempt to reconnect or handle error
+      port = null; // Reset port
+      connectToNativeHost(); // Try to reconnect
+    }
+  } else {
+    console.error("Native host port not connected. Attempting to reconnect.");
+    connectToNativeHost(); // Try to connect if not already
+    // Optionally queue the message or inform the user/content script
+  }
+}
+
+// Function to connect to the native messaging host
+function connectToNativeHost() {
+  if (port) {
+    console.log("Already connected or connecting to native host.");
+    return;
+  }
+  console.log(`Attempting to connect to native host: ${nativeHostName}`);
+  try {
+    port = browser.runtime.connectNative(nativeHostName);
+    console.log("Successfully connected to native host.");
+
+    port.onMessage.addListener((response) => {
+      console.log("Received from native host:", response);
+      // Forward the response to the appropriate content script
+      // We need the tabId to send it to the correct content script.
+      // The content script should pass its tabId when sending the initial message,
+      // or we can try to get the active tab.
+      if (response.tabId) {
+        browser.tabs.sendMessage(response.tabId, {
+          type: "FROM_NATIVE_HOST",
+          payload: response.payload
+        }).catch(err => console.error("Error sending message to content script:", err));
+      } else {
+        console.warn("No tabId in response from native host. Cannot forward to content script.", response);
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      console.log("Disconnected from native host.");
+      if (port.error) {
+        console.error("Native host disconnect error:", port.error.message);
+      }
+      port = null; // Reset port so connectToNativeHost can try again
+    });
+
+  } catch (error) {
+    console.error("Error connecting to native host:", error);
+    port = null;
+  }
+}
+
+// Listen for messages from content scripts
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log("Message received in background script from content script:", message);
+  if (message.type === "TOOL_CALL_DETECTED") {
+    if (!port) {
+        connectToNativeHost();
+    }
+    if (port) {
+        // Add tabId to the message so native host can send it back
+        // allowing background script to route response to correct tab.
+        const messageToNative = {
+            ...message,
+            tabId: sender.tab ? sender.tab.id : null
+        };
+        sendToNativeHost(messageToNative);
+        // sendResponse({ status: "Message forwarded to native host." }); // Optional: acknowledge receipt
+    } else {
+        console.error("Failed to connect to native host. Message not sent.");
+        // sendResponse({ status: "Failed to forward message.", error: "Native host connection failed." });
+    }
+    // Return true if you want to send a response asynchronously.
+    // For now, we are not sending an immediate response back to content script from here.
+    return false;
+  }
+  return false; // Default handling for other messages
+});
+
+// Initial connection attempt when the background script loads
+connectToNativeHost();
+
+// Keep alive for event-based background scripts (Manifest V2)
+// This is generally not needed if you have active listeners like onMessage or connectNative.
+// browser.alarms.create('keepAlive', { periodInMinutes: 4.9 });
+// browser.alarms.onAlarm.addListener(alarm => {
+//   if (alarm.name === 'keepAlive') {
+//     console.log('Keep-alive alarm fired.');
+//     if (!port) {
+//       connectToNativeHost();
+//     }
+//   }
+// });

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,32 @@
 {
   "manifest_version": 2,
   "name": "Gemini MCP Client",
-  "version": "0.1.0",
-  "description": "Monitors gemini.google.com for tool calls and intercepts them.",
+  "version": "0.2.0",
+  "description": "Monitors gemini.google.com for tool calls and intercepts them via a native messaging host.",
   "permissions": [
     "activeTab",
+    "nativeMessaging",
     "https://gemini.google.com/*"
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "content_scripts": [
     {
       "matches": ["https://gemini.google.com/*"],
       "js": ["content_script.js"]
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "gemini-mcp-client@example.com"
+    }
+  },
+  "native_messaging_hosts": {
+    "mcp_native_host": {
+      "description": "Native messaging host for Gemini MCP Client",
+      "path": "mcp_native_host_manifest.json",
+      "type": "stdio"
+    }
+  }
 }

--- a/mcp_native_host.py
+++ b/mcp_native_host.py
@@ -1,0 +1,106 @@
+import sys
+import json
+import struct
+
+# Python 3.x version
+# For Python 2.x, adjustments for string/byte handling might be needed.
+
+# Helper function to read a message from stdin
+def get_message():
+    raw_length = sys.stdin.buffer.read(4)
+    if not raw_length:
+        # This can happen if the browser closes the connection.
+        return None
+    message_length = struct.unpack('@I', raw_length)[0]
+    message = sys.stdin.buffer.read(message_length).decode('utf-8')
+    return json.loads(message)
+
+# Helper function to send a message to stdout
+def send_message(message_content):
+    encoded_content = json.dumps(message_content).encode('utf-8')
+    message_length = struct.pack('@I', len(encoded_content))
+    sys.stdout.buffer.write(message_length)
+    sys.stdout.buffer.write(encoded_content)
+    sys.stdout.buffer.flush()
+
+# Example function to send a response back to the extension
+# This would be called after processing a tool call and getting a result.
+def send_example_response(original_message_tab_id, received_payload):
+    # Construct your response payload
+    response_payload = {
+        "status": "success",
+        "text_response": f"Python script processed: {received_payload.get('raw_xml', 'No raw_xml found')[:50]}...",
+        "original_request": received_payload
+    }
+
+    message_to_send = {
+        "tabId": original_message_tab_id, # Crucial for routing in background.js
+        "payload": response_payload
+    }
+    # send_message(message_to_send) # Uncomment to send this example response
+    # For debugging, let's print what would be sent
+    print_debug(f"If uncommented, would send to extension: {json.dumps(message_to_send)}")
+
+
+# Function to print debug messages to stderr (so it doesn't interfere with stdout protocol)
+def print_debug(message):
+    sys.stderr.write(str(message) + '\n')
+    sys.stderr.flush()
+
+def main():
+    print_debug("MCP Native Host script started.")
+    while True:
+        try:
+            received_message = get_message()
+            if received_message is None:
+                print_debug("No message received, browser might have closed connection. Exiting.")
+                break # Exit loop if connection is closed
+
+            print_debug(f"Received message: {json.dumps(received_message)}")
+
+            # For now, just print the received tool call to the script's console (stderr)
+            # In a real scenario, you would process `received_message.payload`
+            # and potentially call an MCP server.
+
+            # Example of how you might call the function to send a response:
+            # if received_message.get("type") == "TOOL_CALL_DETECTED":
+            #    tab_id = received_message.get("tabId")
+            #    payload = received_message.get("payload")
+            #    if tab_id and payload:
+            #        # This is where you would do actual work and then send a real response
+            #        send_example_response(tab_id, payload) # Call the example response function
+            #    else:
+            #        print_debug("Message was not a tool call or missing tabId/payload.")
+
+            # Simple echo for testing bidirectional communication (uncomment to test)
+            # tab_id = received_message.get("tabId")
+            # if tab_id:
+            #     send_message({
+            #         "tabId": tab_id,
+            #         "payload": {
+            #             "text_response": f"Python script echoing: {received_message.get('payload', {}).get('raw_xml', 'N/A')}"
+            #         }
+            #     })
+            #     print_debug("Sent echo response back to extension.")
+
+
+        except EOFError:
+            print_debug("EOF encountered, stdin closed. Exiting.")
+            break # stdin closed, exit loop
+        except Exception as e:
+            print_debug(f"Error processing message: {e}")
+            # Depending on the error, you might want to break or continue
+            # If it's a struct.error due to malformed length, best to exit.
+            if isinstance(e, struct.error):
+                print_debug("Struct error, likely malformed message length. Exiting.")
+                break
+            # Continue for other errors for now, or implement more robust error handling.
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print_debug(f"Unhandled exception in main: {e}")
+        sys.exit(1)
+
+```

--- a/mcp_native_host_manifest.json
+++ b/mcp_native_host_manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "mcp_native_host",
+  "description": "Native Messaging Host for Gemini MCP Client to run Python script.",
+  "path": "mcp_native_host.py",
+  "type": "stdio",
+  "allowed_extensions": [
+    "gemini-mcp-client@example.com"
+  ]
+}


### PR DESCRIPTION
Here are the key changes:
- I updated `manifest.json` by adding the `nativeMessaging` permission, a background script, and a native messaging host definition. I also bumped the version to 0.2.0.
- I added `background.js` to manage the connection and message relay between the content script and the native Python host.
- I modified `content_script.js` to send detected requests to `background.js` and listen for responses to inject into the Gemini chat interface. This includes placeholder DOM selectors for Gemini's input and send button.
- I added `mcp_native_host.py`, a Python script that listens for requests from the extension via stdio, prints them, and includes a commented-out example for sending responses back.
- I added `mcp_native_host_manifest.json`, which is a manifest file for Firefox to discover and run the Python native messaging host.
- I updated `README.md` to provide comprehensive setup instructions for both the extension and the native messaging components. This includes Python script preparation, native host manifest registration for Windows, Linux, and macOS, and debugging advice.

This architecture allows for more complex processing of requests outside the browser environment and enables bidirectional communication between the extension and the Python script.