### PR TITLE
Fix: Correctly escape call_id in content_script.js querySelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,32 +23,23 @@ Setting up this extension involves two main parts: loading the Firefox extension
 
 ### 1. Firefox Extension Setup
 
-1 **Download or Clone:** 
- * Ensure you have all extension files (`manifest.json`, `content_script.js`, `background.js`, `mcp_native_host.py`, `mcp_native_host_manifest.json`, and this `README.md`) in a local directory.
-   
-2 **Open Firefox.**
-   
-3 **Navigate to Add-ons:**
-   
-  *   Type `about:debugging` in the address bar and press Enter.
-  *   Alternatively, click the menu button (☰) -> Add-ons and themes -> Extensions.
-      
-4 **Load Temporary Add-on:**
-   
-  *   In the `about:debugging` page, click on "This Firefox" (or your Firefox version) on the left sidebar.
-  *   Click the "Load Temporary Add-on…" button.
-      
-5 **Select the Manifest File:**
-   
-  *   Browse to the directory where you saved the extension files.
-  *   Select the main extension `manifest.json` file and click "Open".
+   a. **Download or Clone:** Ensure you have all extension files (`manifest.json`, `content_script.js`, `background.js`, `mcp_native_host.py`, `mcp_native_host_manifest.json`, and this `README.md`) in a local directory.
+   b. **Open Firefox.**
+   c. **Navigate to Add-ons:**
+      *   Type `about:debugging` in the address bar and press Enter.
+      *   Alternatively, click the menu button (☰) -> Add-ons and themes -> Extensions.
+   d. **Load Temporary Add-on:**
+      *   In the `about:debugging` page, click on "This Firefox" (or your Firefox version) on the left sidebar.
+      *   Click the "Load Temporary Add-on…" button.
+   e. **Select the Manifest File:**
+      *   Browse to the directory where you saved the extension files.
+      *   Select the main extension `manifest.json` file and click "Open".
 
 ### 2. Python Native Messaging Host Setup
 
 This is the more complex part and requires careful setup. The extension needs to communicate with the `mcp_native_host.py` script.
 
-   1 **Install Python:**
-   
+   a. **Install Python:**
       *   Ensure you have Python 3 installed. You can download it from [python.org](https://www.python.org/).
       *   Verify it's in your system's PATH.
 
@@ -60,20 +51,16 @@ This is the more complex part and requires careful setup. The extension needs to
       Since `fastmcp` is hypothetical for this project, the script includes an internal mock for basic structural execution if the library is not found. This allows the script to run for development and testing of other features, but it will not perform real tool discovery without the actual library.
 
    c. **Prepare the Python Script (`mcp_native_host.py`):**
-
       *   This script is included in the repository.
       *   **On Linux/macOS:** Make it executable: `chmod +x /path/to/your/mcp_native_host.py`
       *   Ensure it has the correct shebang line at the top: `#!/usr/bin/env python3` (or your Python 3 path).
       *   Place this script in a known location. For example, you can place it in the same directory where you will put the native messaging host manifest file (see next step), or another directory of your choice.
 
-   3 **Configure and Register the Native Messaging Host Manifest (`mcp_native_host_manifest.json`):**
-   
+   c. **Configure and Register the Native Messaging Host Manifest (`mcp_native_host_manifest.json`):**
       This JSON file tells Firefox where to find your Python script and which extension can talk to it.
-      
-   * **Edit `mcp_native_host_manifest.json`:**
-     The provided `mcp_native_host_manifest.json` has a `"path"` field:
-     
-     ```json
+      *   **Edit `mcp_native_host_manifest.json`:**
+          The provided `mcp_native_host_manifest.json` has a `"path"` field:
+          ```json
           {
             "name": "mcp_native_host",
             "description": "Native Messaging Host for Gemini MCP Client to run Python script.",
@@ -83,12 +70,11 @@ This is the more complex part and requires careful setup. The extension needs to
               "gemini-mcp-client@example.com"
             ]
           }
-          
-     ```
-     You **MUST** update the `"path"` value in `mcp_native_host_manifest.json` to be the **absolute path** to your `mcp_native_host.py` script.
-     For example:
-      - Windows: `"path": "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"` (use double backslashes) or you might need to invoke python directly like `"path": "C:\\Path\\To\\Python\\python.exe", "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"`. Simpler is often a .bat wrapper.
-      - Linux/macOS: `"path": "/home/yourname/path/to/mcp_native_host.py"`
+          ```
+          You **MUST** update the `"path"` value in `mcp_native_host_manifest.json` to be the **absolute path** to your `mcp_native_host.py` script.
+          For example:
+            - Windows: `"path": "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"` (use double backslashes) or you might need to invoke python directly like `"path": "C:\\Path\\To\\Python\\python.exe", "C:\\Users\\YourName\\path\\to\\mcp_native_host.py"`. Simpler is often a .bat wrapper.
+            - Linux/macOS: `"path": "/home/yourname/path/to/mcp_native_host.py"`
 
       *   **Place the edited `mcp_native_host_manifest.json` into the correct Firefox directory, naming the file `mcp_native_host.json` (matching the `"name"` field):**
           *   **Windows:**

--- a/content_script.js
+++ b/content_script.js
@@ -241,7 +241,8 @@ function detectToolCallInMutation(mutation) {
                     invokeToMark = addedNode;
                 } else if (typeof addedNode.querySelectorAll === 'function'){
                     // Query within the context of the addedNode that contained the tool call string
-                    invokeToMark = addedNode.querySelector(`invoke[call_id="${parsedToolData.call_id}"]`);
+                    const callIdValue = String(parsedToolData.call_id).replace(/"/g, '\\"'); // Replaces " with \\"
+                    invokeToMark = addedNode.querySelector(`invoke[call_id="${callIdValue}"]`);
                 }
 
                 if (invokeToMark) {


### PR DESCRIPTION
This commit fixes a JavaScript SyntaxError in `content_script.js` that could occur if a `call_id` attribute contained double quotes.

The `detectToolCallInMutation` function uses `querySelector` with a CSS attribute selector like `invoke[call_id="..."]`. If the `call_id` value itself contained a double quote, it would break the selector string, leading to a syntax error.

The fix ensures that the `call_id` value is explicitly converted to a string and any double quotes within it are properly escaped (e.g., `"` becomes `\"`) before being injected into the selector template literal. This makes the querySelector robust against such `call_id` values.