### PR TITLE
Fix: Further enhance call_id escaping in content_script.js selector

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -241,7 +241,7 @@ function detectToolCallInMutation(mutation) {
                     invokeToMark = addedNode;
                 } else if (typeof addedNode.querySelectorAll === 'function'){
                     // Query within the context of the addedNode that contained the tool call string
-                    const callIdValue = String(parsedToolData.call_id).replace(/"/g, '\\"'); // Replaces " with \\"
+                    const callIdValue = String(parsedToolData.call_id).replace(/"/g, '\\"').replace(/`/g, '\\`'); // Escape " as \\" and ` as \\`
                     invokeToMark = addedNode.querySelector(`invoke[call_id="${callIdValue}"]`);
                 }
 


### PR DESCRIPTION
This commit provides an additional fix for a persistent JavaScript SyntaxError in `content_script.js`. The error was suspected to be caused by special characters in `call_id` attributes breaking the template literal used for a `querySelector` CSS attribute selector.

The `detectToolCallInMutation` function constructs a selector like `invoke[call_id="..."]`. While previous fixes handled escaping for double quotes (`"`) within the `call_id` value, this commit extends the escaping to also include backticks (`` ` ``).

If a `call_id` value contained a backtick, it could prematurely terminate the template literal, leading to a syntax error. Both double quotes and backticks are now escaped in the `call_id` string before it's interpolated into the selector.