### PR TITLE
Alright, I've implemented Phase 3: Update extension and document venv…

### DIFF
--- a/mcp_native_host.py
+++ b/mcp_native_host.py
@@ -525,6 +525,23 @@ def main():
                 if tab_id:
                     send_message({"tabId": tab_id, "payload": {"type": "PONG", "message": "Python host says PONG!"}})
 
+            elif message_type == "REQUEST_PROMPT":
+                print_debug(f"Received REQUEST_PROMPT message. Tab ID: {tab_id}")
+                # Ensure tab_id is present, though background.js should always send it
+                if tab_id is None:
+                    print_debug("Error: REQUEST_PROMPT received without a tabId. Cannot respond.")
+                else:
+                    dummy_prompt = "Test message from MCP Client: Describe the process of photosynthesis."
+                    response_message = {
+                        "tabId": tab_id,
+                        "payload": {
+                            "type": "PROMPT_RESPONSE",
+                            "prompt": dummy_prompt
+                        }
+                    }
+                    send_message(response_message)
+                    print_debug(f"Sent PROMPT_RESPONSE with dummy prompt to tabId: {tab_id}")
+
 
         except EOFError: print_debug("EOF encountered, stdin closed. Exiting."); break
         except Exception as e:


### PR DESCRIPTION
… setup.

Here's a summary of the changes:

- Browser Extension Updates (Phase 3, Part 1):
    - I've renamed the "Inject Dummy Prompt" button to "Inject Prompt".
    - The "Inject Prompt" button now fetches a prompt from the `mcp_native_host.py` script via `background.js`.
    - For now, the Python script returns the same dummy prompt as before.
    - I've modified `content_script.js`, `background.js`, and `mcp_native_host.py` to support this new message flow for prompts.

- README.md Enhancements:
    - I've added a comprehensive section on setting up and using a Python virtual environment (`venv`) for the `mcp_native_host.py` script.
    - This includes instructions for creating, activating, and installing dependencies within the venv.
    - I've recommended using a wrapper script (`run_native_host.sh` or `run_native_host.bat`) to ensure the native host runs with the venv's Python interpreter and packages.
    - I've detailed how to update the `mcp_native_host.json` manifest to use this wrapper script.
    - This should address issues you might have encountered with installing packages like `fastmcp` globally.