### PR TITLE
Fix: Resolve startup errors and improve setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This is the more complex part and requires careful setup. The extension needs to
 
    c. **Prepare the Python Script (`mcp_native_host.py`):**
       *   This script is included in the repository.
-      *   **On Linux/macOS:** Make it executable: `chmod +x /path/to/your/mcp_native_host.py`. This is good practice even if using a wrapper script.
+      *   **On Linux/macOS:** Make it executable: `chmod +x /path/to/your/mcp_native_host.py`. This is good practice even if using a wrapper script. You may need to re-run this command if you find the script loses its executable permission after pulling updates from the repository.
       *   Ensure it has the correct shebang line at the top: `#!/usr/bin/env python3`. This is mainly relevant if you were to run the script directly or use Method 1 for venv configuration (not detailed here but mentioned in earlier discussions). With the wrapper script method, the wrapper explicitly calls the venv's Python.
       *   Place this script in a known location (e.g., your project directory).
 

--- a/mcp_native_host.py
+++ b/mcp_native_host.py
@@ -7,6 +7,12 @@ import struct
 import os
 import xml.etree.ElementTree as ET
 
+# Moved print_debug definition earlier to ensure it's available for the mock client definitions
+# and the initial FASTMCP_AVAILABLE check.
+def print_debug(message):
+    sys.stderr.write(str(message) + '\n')
+    sys.stderr.flush()
+
 # Attempt to import fastmcp, provide a mock if not found for basic script structure to be valid
 try:
     import fastmcp.client
@@ -104,7 +110,7 @@ except ImportError:
         fastmcp = fastmcp_module_mock
 
 # Base system prompt including a placeholder for the dynamic tool list
-BASE_SYSTEM_PROMPT = """You are a powerful AI assistant with access to a suite of tools. When you need to use a tool, you must respond in the following XML format. You may use tools sequentially if needed.
+BASE_SYSTEM_PROMPT = r"""You are a powerful AI assistant with access to a suite of tools. When you need to use a tool, you must respond in the following XML format. You may use tools sequentially if needed.
 
 <tool_code>
 <tool_name>example_tool_name</tool_name>
@@ -124,9 +130,7 @@ DISCOVERED_TOOLS = []
 PROCESSED_CALL_IDS = set()
 FORMATTED_TOOL_LIST_MD = "" # Global variable to store the formatted tool list
 
-def print_debug(message):
-    sys.stderr.write(str(message) + '\n')
-    sys.stderr.flush()
+# print_debug is now defined much earlier in the script.
 
 def get_message():
     raw_length = sys.stdin.buffer.read(4)


### PR DESCRIPTION
This commit addresses several issues affecting the native messaging host:

1.  **Correct `SyntaxWarning` in `mcp_native_host.py`:** The `BASE_SYSTEM_PROMPT` string was changed to a raw string literal (r"""...") to prevent `SyntaxWarning: invalid escape sequence '\S'`.

2.  **Resolve `NameError` for `print_debug` in `mcp_native_host.py`:** The `print_debug` function definition has been moved to an earlier point in the script, before its first potential call during the `fastmcp` import exception handling. This fixes a `NameError` that occurred when `fastmcp` was not found.

3.  **Improve Executable Bit Guidance in `README.md`:** Added a note to `README.md` advising you on Linux/macOS that you may need to re-apply `chmod +x` to `mcp_native_host.py` if it loses executable permissions after repository updates.

These changes ensure smoother startup and operation of the native host, especially when the `fastmcp` library is not yet installed, and provide better guidance for you.