### PR TITLE
fix: Ensure dropdown menu is visible by expanding code

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -254,6 +254,10 @@ function handleFoundCodeElement(codeElement, sourceType) {
             dropdownMenu.classList.remove('mcp-active');
             // toolCallBarArrow.innerHTML = '▼'; // Change arrow back if stateful
         } else {
+            // Ensure the code block is visible before showing the menu
+            if (effectiveTargetElement) {
+                effectiveTargetElement.style.display = ''; // Revert to default display (block, inline, etc.)
+            }
             dropdownMenu.style.display = 'block';
             dropdownMenu.classList.add('mcp-active');
             // toolCallBarArrow.innerHTML = '▶'; // Change arrow to indicate open if stateful


### PR DESCRIPTION
This commit addresses an issue where the dropdown menu could be cut off if there wasn't enough space below it.

The click listener for the dropdown arrow (`toolCallBarArrow`) in `content_script.js` has been modified. Now, in addition to toggling the dropdown menu, it also ensures that the original code block (or its wrapper) is made visible. This action provides the necessary space for the dropdown to be displayed without being clipped by parent containers with `overflow: hidden` or fixed heights.

The independent functionality of clicking the main text part of the bar to toggle the code block's visibility is preserved.