### PR TITLE
fix: Correctly unescape and detect tool result XML in chat history

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -138,19 +138,16 @@ function processPotentialMessageContainer(containerElement) {
 
     reconstructedXml = reconstructedXml.trim(); // Trim whitespace
 
-    // Unescape HTML entities like &lt; and &gt; to get actual XML tags for reliable checking
-    // It's crucial to do this *before* checking startsWith/endsWith
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = reconstructedXml;
-    const unescapedXml = tempDiv.textContent || tempDiv.innerText || "";
+    // Use the new unescapeHtmlEntities function
+    const unescapedXml = unescapeHtmlEntities(reconstructedXml);
 
     console.log("Gemini MCP Client [DEBUG]: Reconstructed and Unescaped XML from message container:", unescapedXml.substring(0, 200) + "...");
 
-    // Check if it's a tool result
-    if (unescapedXml.startsWith("<tool_result") && unescapedXml.endsWith("</tool_result>")) {
+    // Check if it's a tool result, using trim() on the unescaped XML
+    if (unescapedXml.trim().startsWith("<tool_result") && unescapedXml.trim().endsWith("</tool_result>")) {
         console.log("Gemini MCP Client [DEBUG]: Identified tool result in message container:", containerElement);
         // Mark the container as processed by this specific path to avoid re-entry from other observers if any overlap
-        // containerElement.dataset.mcpProcessed = 'true'; // Or handle this within handleFoundCodeElement
+        // containerElement.dataset.mcpProcessed = 'true'; // This is handled by handleFoundCodeElement on the passedElement
 
         // Call handleFoundCodeElement, passing the container as the element to be replaced,
         // and the reconstructed/unescaped XML.


### PR DESCRIPTION
This commit addresses a bug where tool results rendered by Gemini (often as multiple HTML-escaped lines within paragraph tags) were not being correctly identified and transformed into the foldable UI.

The core issue was in the unescaping process within `processPotentialMessageContainer`. Previously, attempting to unescape by setting `innerHTML` on a temporary div and then reading its `textContent` would strip the XML tags themselves, leaving only their inner text. This caused the subsequent string matching for `<tool_result>` tags to fail.

Changes:
1.  **Introduced `unescapeHtmlEntities` Helper:**
    - A new function `unescapeHtmlEntities(htmlStringWithEntities)` was added. It uses a temporary `textarea` element's `innerHTML` and `value` properties to reliably decode HTML entities (e.g., `&lt;` to `<`) while preserving the overall string structure, including tags.

2.  **Updated `processPotentialMessageContainer`:**
    - It now uses `unescapeHtmlEntities` to decode the reconstructed XML string that was assembled from multiple `<p>` tags.
    - The condition to identify a tool result now checks `unescapedXml.trim().startsWith("<tool_result")` and `unescapedXml.trim().endsWith("</tool_result>")`, ensuring robustness against potential leading/trailing whitespace after unescaping.

With these changes, the full tool result XML, including its tags, is correctly reconstructed and unescaped, allowing for accurate detection and subsequent transformation into the interactive foldable UI bar.